### PR TITLE
[Api-response-type] 네트워크 통신 응답 결과 처리

### DIFF
--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/model/ImageContent.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/model/ImageContent.kt
@@ -1,0 +1,12 @@
+package com.ranicorp.letswatchfootballtogether.data.model
+
+import android.net.Uri
+
+data class ImageContentHeader(
+    val size: Int,
+    val limit: Int
+)
+
+data class ImageContent(
+    val uri: Uri
+)

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/remote/ApiClient.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/remote/ApiClient.kt
@@ -3,50 +3,50 @@ package com.ranicorp.letswatchfootballtogether.data.source.remote
 import com.ranicorp.letswatchfootballtogether.data.model.Message
 import com.ranicorp.letswatchfootballtogether.data.model.Post
 import com.ranicorp.letswatchfootballtogether.data.model.User
-import retrofit2.Response
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiResponse
 import retrofit2.http.*
 
 interface ApiClient {
 
     @GET("userNickNames.json")
-    suspend fun getUserNickNames(): Response<Map<String, String>>
+    suspend fun getUserNickNames(): ApiResponse<Map<String, String>>
 
     @POST("userNickNames.json")
-    suspend fun addUserNickName(@Body userNickName: String): Response<Map<String, String>>
+    suspend fun addUserNickName(@Body userNickName: String): ApiResponse<Map<String, String>>
 
     @POST("users/{uid}.json")
-    suspend fun addUser(@Path("uid") uid: String, @Body user: User): Response<Map<String, String>>
+    suspend fun addUser(@Path("uid") uid: String, @Body user: User): ApiResponse<Map<String, String>>
 
     @POST("posts/{postUid}.json")
-    suspend fun addPost(@Path("postUid") postUid: String, @Body post: Post): Response<Map<String, String>>
+    suspend fun addPost(@Path("postUid") postUid: String, @Body post: Post): ApiResponse<Map<String, String>>
 
     @GET("posts.json")
-    suspend fun getAllPosts(): Response<Map<String, Map<String, Post>>>
+    suspend fun getAllPosts(): ApiResponse<Map<String, Map<String, Post>>>
 
     @GET("users.json")
-    suspend fun getAllUsers(): Response<Map<String, Map<String, User>>>
+    suspend fun getAllUsers(): ApiResponse<Map<String, Map<String, User>>>
 
     @PUT("posts/{postUid}/{firebaseUid}.json")
-    suspend fun updatePost(@Path("postUid") postUid: String, @Path("firebaseUid") firebaseUid: String, @Body post: Post): Response<Post>
+    suspend fun updatePost(@Path("postUid") postUid: String, @Path("firebaseUid") firebaseUid: String, @Body post: Post): ApiResponse<Post>
 
     @PUT("users/{uid}/{firebaseUid}.json")
-    suspend fun updateUser(@Path("uid") uid: String, @Path("firebaseUid") firebaseUid: String, @Body user: User): Response<User>
+    suspend fun updateUser(@Path("uid") uid: String, @Path("firebaseUid") firebaseUid: String, @Body user: User): ApiResponse<User>
 
     @GET("posts/{postUid}/{firebaseUid}.json")
-    suspend fun getPost(@Path("postUid") postUid: String, @Path("firebaseUid") firebaseUid: String): Response<Post>
+    suspend fun getPost(@Path("postUid") postUid: String, @Path("firebaseUid") firebaseUid: String): ApiResponse<Post>
 
     @GET("posts/{postUid}.json")
-    suspend fun getPostNoFirebaseUid(@Path("postUid") postUid: String): Response<Map<String, Post>>
+    suspend fun getPostNoFirebaseUid(@Path("postUid") postUid: String): ApiResponse<Map<String, Post>>
 
     @POST("chat/{postUid}.json")
-    suspend fun addChat(@Path("postUid") postUid: String, @Body message: Message): Response<Map<String, String>>
+    suspend fun addChat(@Path("postUid") postUid: String, @Body message: Message): ApiResponse<Map<String, String>>
 
     @GET("chat/{postUid}.json")
-    suspend fun getAllChat(@Path("postUid") postUid: String): Response<Map<String, Message>>
+    suspend fun getAllChat(@Path("postUid") postUid: String): ApiResponse<Map<String, Message>>
 
     @GET("users/{userUid}/{firebaseUid}.json")
-    suspend fun getUser(@Path("userUid") userUid: String, @Path("firebaseUid") firebaseUid: String): Response<User>
+    suspend fun getUser(@Path("userUid") userUid: String, @Path("firebaseUid") firebaseUid: String): ApiResponse<User>
 
     @GET("users/{userUid}.json")
-    suspend fun getUserNoFirebaseUid(@Path("userUid") userUid: String): Response<Map<String, User>>
+    suspend fun getUserNoFirebaseUid(@Path("userUid") userUid: String): ApiResponse<Map<String, User>>
 }

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/remote/NetworkModule.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/remote/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.ranicorp.letswatchfootballtogether.data.source.remote
 
 import com.google.firebase.storage.FirebaseStorage
 import com.ranicorp.letswatchfootballtogether.BuildConfig
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiCallAdapterFactory
 import com.squareup.moshi.Moshi
 import dagger.Module
 import dagger.Provides
@@ -46,6 +47,7 @@ object NetworkModule {
             .baseUrl(BuildConfig.BASE_URL)
             .client(client)
             .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .addCallAdapterFactory(ApiCallAdapterFactory.create())
             .build()
     }
 

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/remote/RemoteDataSource.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/remote/RemoteDataSource.kt
@@ -8,71 +8,74 @@ import com.google.firebase.ktx.Firebase
 import com.ranicorp.letswatchfootballtogether.data.model.Message
 import com.ranicorp.letswatchfootballtogether.data.model.Post
 import com.ranicorp.letswatchfootballtogether.data.model.User
-import retrofit2.Response
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiResponse
 import javax.inject.Inject
 
 class RemoteDataSource @Inject constructor(private val apiClient: ApiClient) {
 
-    suspend fun getUserNickNames(): Response<Map<String, String>> {
+    suspend fun getUserNickNames(): ApiResponse<Map<String, String>> {
         return apiClient.getUserNickNames()
     }
 
-    suspend fun addUserNickName(userNickName: String): Response<Map<String, String>> {
+    suspend fun addUserNickName(userNickName: String): ApiResponse<Map<String, String>> {
         return apiClient.addUserNickName(userNickName)
     }
 
-    suspend fun addUser(uid: String, user: User): Response<Map<String, String>> {
+    suspend fun addUser(uid: String, user: User): ApiResponse<Map<String, String>> {
         return apiClient.addUser(uid, user)
     }
 
-    suspend fun addPost(postUid: String, post: Post): Response<Map<String, String>> {
+    suspend fun addPost(postUid: String, post: Post): ApiResponse<Map<String, String>> {
         return apiClient.addPost(postUid, post)
     }
 
-    suspend fun getAllPosts(): Response<Map<String, Map<String, Post>>> {
+    suspend fun getAllPosts(): ApiResponse<Map<String, Map<String, Post>>> {
         return apiClient.getAllPosts()
     }
 
-    suspend fun getAllUsers(): Response<Map<String, Map<String, User>>> {
+    suspend fun getAllUsers(): ApiResponse<Map<String, Map<String, User>>> {
         return apiClient.getAllUsers()
     }
 
-    suspend fun updatePost(postUid: String, firebaseUid: String, post: Post): Response<Post> {
+    suspend fun updatePost(postUid: String, firebaseUid: String, post: Post): ApiResponse<Post> {
         return apiClient.updatePost(postUid, firebaseUid, post)
     }
 
-    suspend fun updateUser(uid: String, firebaseUid: String, user: User): Response<User> {
+    suspend fun updateUser(uid: String, firebaseUid: String, user: User): ApiResponse<User> {
         return apiClient.updateUser(uid, firebaseUid, user)
     }
 
-    suspend fun getPost(postUid: String, firebaseUid: String): Response<Post> {
+    suspend fun getPost(postUid: String, firebaseUid: String): ApiResponse<Post> {
         return apiClient.getPost(postUid, firebaseUid)
     }
 
-    suspend fun getPostNoFirebaseUid(postUid: String): Response<Map<String, Post>> {
+    suspend fun getPostNoFirebaseUid(postUid: String): ApiResponse<Map<String, Post>> {
         return apiClient.getPostNoFirebaseUid(postUid)
     }
 
     suspend fun addChat(
         postUid: String,
         message: Message
-    ): Response<Map<String, String>> {
+    ): ApiResponse<Map<String, String>> {
         return apiClient.addChat(postUid, message)
     }
 
-    suspend fun getAllChat(postUid: String): Response<Map<String, Message>> {
+    suspend fun getAllChat(postUid: String): ApiResponse<Map<String, Message>> {
         return apiClient.getAllChat(postUid)
     }
 
-    suspend fun getUser(userUid: String, firebaseUid: String): Response<User> {
+    suspend fun getUser(userUid: String, firebaseUid: String): ApiResponse<User> {
         return apiClient.getUser(userUid, firebaseUid)
     }
 
-    suspend fun getUserNoFirebaseUid(userUid: String): Response<Map<String, User>> {
+    suspend fun getUserNoFirebaseUid(userUid: String): ApiResponse<Map<String, User>> {
         return apiClient.getUserNoFirebaseUid(userUid)
     }
 
-    fun addChatEventListener(chatRoomUid: String, onChatItemAdded: (Message) -> Unit): ChildEventListener {
+    fun addChatEventListener(
+        chatRoomUid: String,
+        onChatItemAdded: (Message) -> Unit
+    ): ChildEventListener {
         val chatEventListener = object : ChildEventListener {
             override fun onChildAdded(snapshot: DataSnapshot, previousChildName: String?) {
                 val chatItem = snapshot.getValue(Message::class.java)
@@ -91,7 +94,8 @@ class RemoteDataSource @Inject constructor(private val apiClient: ApiClient) {
             override fun onCancelled(error: DatabaseError) {
             }
         }
-        val database = Firebase.database(com.ranicorp.letswatchfootballtogether.BuildConfig.BASE_URL
+        val database = Firebase.database(
+            com.ranicorp.letswatchfootballtogether.BuildConfig.BASE_URL
         ).reference
         database.child("chat").child(chatRoomUid).addChildEventListener(chatEventListener)
         return chatEventListener

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/remote/apicalladapter/ApiCall.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/remote/apicalladapter/ApiCall.kt
@@ -1,0 +1,55 @@
+package com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter
+
+import okhttp3.Request
+import okio.Timeout
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.HttpException
+import retrofit2.Response
+
+class ApiCall<T : Any>(private val call: Call<T>) : Call<ApiResponse<T>> {
+    override fun enqueue(callback: Callback<ApiResponse<T>>) {
+        call.enqueue(object : Callback<T> {
+            override fun onResponse(call: Call<T>, response: Response<T>) {
+                val networkResult = try {
+                    val body = response.body()
+                    if (response.isSuccessful && body != null) {
+                        ApiResultSuccess(body)
+                    } else {
+                        ApiResultError(code = response.code(), message = response.message())
+                    }
+                } catch (e: HttpException) {
+                    ApiResultError(code = e.code(), message = e.message())
+                } catch (t: Throwable) {
+                    ApiResultException(t)
+                }
+                callback.onResponse(this@ApiCall, Response.success(networkResult))
+            }
+
+            override fun onFailure(call: Call<T>, t: Throwable) {
+                val networkResult = ApiResultException<T>(t)
+                callback.onResponse(this@ApiCall, Response.success(networkResult))
+            }
+        })
+    }
+
+    override fun clone(): Call<ApiResponse<T>> {
+        return ApiCall(call.clone())
+    }
+
+    override fun execute(): Response<ApiResponse<T>> {
+        throw NotImplementedError()
+    }
+
+    override fun isExecuted(): Boolean = call.isExecuted
+
+    override fun cancel() {
+        call.cancel()
+    }
+
+    override fun isCanceled(): Boolean = call.isCanceled
+
+    override fun request(): Request = call.request()
+
+    override fun timeout(): Timeout = call.timeout()
+}

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/remote/apicalladapter/ApiCallAdapter.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/remote/apicalladapter/ApiCallAdapter.kt
@@ -1,0 +1,41 @@
+package com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter
+
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Retrofit
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
+
+class ApiCallAdapter(
+    private val type: Type
+) : CallAdapter<Type, Call<ApiResponse<Type>>> {
+    override fun responseType(): Type = type
+
+    override fun adapt(call: Call<Type>): Call<ApiResponse<Type>> {
+        return ApiCall(call)
+    }
+}
+
+class ApiCallAdapterFactory private constructor() : CallAdapter.Factory() {
+    override fun get(
+        returnType: Type,
+        annotations: Array<out Annotation>,
+        retrofit: Retrofit
+    ): CallAdapter<*, *>? {
+        if (getRawType(returnType) != Call::class.java) {
+            return null
+        }
+
+        val callType = getParameterUpperBound(0, returnType as ParameterizedType)
+        if (getRawType(callType) != ApiResponse::class.java) {
+            return null
+        }
+
+        val resultType = getParameterUpperBound(0, callType as ParameterizedType)
+        return ApiCallAdapter(resultType)
+    }
+
+    companion object {
+        fun create() = ApiCallAdapterFactory()
+    }
+}

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/remote/apicalladapter/ApiResponse.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/remote/apicalladapter/ApiResponse.kt
@@ -1,0 +1,9 @@
+package com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter
+
+sealed interface ApiResponse<T : Any?>
+
+class ApiResultSuccess<T : Any>(val data: T) : ApiResponse<T>
+
+class ApiResultError<T : Any>(val code: Int, val message: String) : ApiResponse<T>
+
+class ApiResultException<T : Any>(val throwable: Throwable) : ApiResponse<T>

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/repository/ChatRepository.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/repository/ChatRepository.kt
@@ -3,16 +3,16 @@ package com.ranicorp.letswatchfootballtogether.data.source.repository
 import com.google.firebase.database.ChildEventListener
 import com.ranicorp.letswatchfootballtogether.data.model.Message
 import com.ranicorp.letswatchfootballtogether.data.source.remote.RemoteDataSource
-import retrofit2.Response
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiResponse
 import javax.inject.Inject
 
 class ChatRepository @Inject constructor(private val remoteDataSource: RemoteDataSource) {
 
-    suspend fun addChat(postUid: String, message: Message): Response<Map<String, String>> {
+    suspend fun addChat(postUid: String, message: Message): ApiResponse<Map<String, String>> {
         return remoteDataSource.addChat(postUid, message)
     }
 
-    suspend fun getAllChat(postUid:String): Response<Map<String, Message>> {
+    suspend fun getAllChat(postUid:String): ApiResponse<Map<String, Message>> {
         return remoteDataSource.getAllChat(postUid)
     }
 

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/repository/PostRepository.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/repository/PostRepository.kt
@@ -2,28 +2,28 @@ package com.ranicorp.letswatchfootballtogether.data.source.repository
 
 import com.ranicorp.letswatchfootballtogether.data.model.Post
 import com.ranicorp.letswatchfootballtogether.data.source.remote.RemoteDataSource
-import retrofit2.Response
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiResponse
 import javax.inject.Inject
 
 class PostRepository @Inject constructor(private val remoteDataSource: RemoteDataSource) {
 
-    suspend fun addPost(postUid: String, post: Post): Response<Map<String, String>> {
+    suspend fun addPost(postUid: String, post: Post): ApiResponse<Map<String, String>> {
         return remoteDataSource.addPost(postUid, post)
     }
 
-    suspend fun getAllPosts(): Response<Map<String, Map<String, Post>>> {
+    suspend fun getAllPosts(): ApiResponse<Map<String, Map<String, Post>>> {
         return remoteDataSource.getAllPosts()
     }
 
-    suspend fun updatePost(postUid: String, firebaseUid: String, post: Post): Response<Post> {
+    suspend fun updatePost(postUid: String, firebaseUid: String, post: Post): ApiResponse<Post> {
         return remoteDataSource.updatePost(postUid, firebaseUid, post)
     }
 
-    suspend fun getPost(postUid: String, firebaseUid: String): Response<Post> {
+    suspend fun getPost(postUid: String, firebaseUid: String): ApiResponse<Post> {
         return remoteDataSource.getPost(postUid, firebaseUid)
     }
 
-    suspend fun getPostNoFirebaseUid(postUid: String): Response<Map<String, Post>> {
+    suspend fun getPostNoFirebaseUid(postUid: String): ApiResponse<Map<String, Post>> {
         return remoteDataSource.getPostNoFirebaseUid(postUid)
     }
 }

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/repository/UserRepository.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/data/source/repository/UserRepository.kt
@@ -2,43 +2,36 @@ package com.ranicorp.letswatchfootballtogether.data.source.repository
 
 import com.ranicorp.letswatchfootballtogether.data.model.User
 import com.ranicorp.letswatchfootballtogether.data.source.remote.RemoteDataSource
-import retrofit2.Response
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiResponse
 import javax.inject.Inject
 
 class UserRepository @Inject constructor(private val remoteDataSource: RemoteDataSource) {
 
-    suspend fun getUserNickNames(): Response<Map<String, String>> {
+    suspend fun getUserNickNames(): ApiResponse<Map<String, String>> {
         return remoteDataSource.getUserNickNames()
     }
 
-    suspend fun addUser(uid: String, user: User): Response<Map<String, String>> {
+    suspend fun addUser(uid: String, user: User): ApiResponse<Map<String, String>> {
         return remoteDataSource.addUser(uid, user)
     }
 
-    suspend fun addUserNickName(nickName: String): Response<Map<String, String>> {
+    suspend fun addUserNickName(nickName: String): ApiResponse<Map<String, String>> {
         return remoteDataSource.addUserNickName(nickName)
     }
 
-    suspend fun getAllUsers(): Response<Map<String, Map<String, User>>> {
+    suspend fun getAllUsers(): ApiResponse<Map<String, Map<String, User>>> {
         return remoteDataSource.getAllUsers()
     }
 
-    suspend fun updateUser(uid: String, firebaseUid: String, user: User): Response<User> {
+    suspend fun updateUser(uid: String, firebaseUid: String, user: User): ApiResponse<User> {
         return remoteDataSource.updateUser(uid, firebaseUid, user)
     }
 
-    suspend fun getUserInfo(userUid: String): User? {
-        val user = getAllUsers().body()?.values?.flatMap { it.values }?.find {
-            it.uid == userUid
-        }
-        return user
-    }
-
-    suspend fun getUser(userUid: String, firebaseUid: String): Response<User> {
+    suspend fun getUser(userUid: String, firebaseUid: String): ApiResponse<User> {
         return remoteDataSource.getUser(userUid, firebaseUid)
     }
 
-    suspend fun getUserNoFirebaseUid(userUid: String): Response<Map<String, User>> {
+    suspend fun getUserNoFirebaseUid(userUid: String): ApiResponse<Map<String, User>> {
         return remoteDataSource.getUserNoFirebaseUid(userUid)
     }
 }

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/chatroom/ChatRoomFragment.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/chatroom/ChatRoomFragment.kt
@@ -51,11 +51,13 @@ class ChatRoomFragment : Fragment() {
         setData()
         viewModel.addChatEventListener()
         viewModel.isLoaded.observe(viewLifecycleOwner, EventObserver {
-            Toast.makeText(
-                context,
-                getString(R.string.error_message_chat_room_loading_failed),
-                Toast.LENGTH_SHORT
-            ).show()
+            if (!it) {
+                Toast.makeText(
+                    context,
+                    getString(R.string.error_message_chat_room_loading_failed),
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
         })
     }
 

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/chatroom/ChatRoomFragment.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/chatroom/ChatRoomFragment.kt
@@ -6,9 +6,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
+import com.ranicorp.letswatchfootballtogether.R
 import com.ranicorp.letswatchfootballtogether.data.model.ChatItem
 import com.ranicorp.letswatchfootballtogether.data.model.ReceivedMessage
 import com.ranicorp.letswatchfootballtogether.data.model.SentMessage
@@ -48,6 +50,13 @@ class ChatRoomFragment : Fragment() {
         sendText()
         setData()
         viewModel.addChatEventListener()
+        viewModel.isLoaded.observe(viewLifecycleOwner, EventObserver {
+            Toast.makeText(
+                context,
+                getString(R.string.error_message_chat_room_loading_failed),
+                Toast.LENGTH_SHORT
+            ).show()
+        })
     }
 
     private fun sendText() {
@@ -57,12 +66,12 @@ class ChatRoomFragment : Fragment() {
             if (actionId == EditorInfo.IME_ACTION_DONE ||
                 (event != null && event.keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_DOWN)
             ) {
-                viewModel.addChat(enteredText)
+                viewModel.sendChat(enteredText)
                 return@setOnEditorActionListener true
             }
             false
         }
-        viewModel.isSent.observe(viewLifecycleOwner, EventObserver {
+        viewModel.isSendingComplete.observe(viewLifecycleOwner, EventObserver {
             if (it) {
                 binding.etWriteText.text.clear()
             }

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/chatroom/ChatRoomViewModel.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/chatroom/ChatRoomViewModel.kt
@@ -34,10 +34,10 @@ class ChatRoomViewModel @Inject constructor(
     private val _isLoaded = MutableLiveData<Event<Boolean>>()
     val isLoaded: LiveData<Event<Boolean>> = _isLoaded
     private var chatEventListener: ChildEventListener? = null
+    private var profileUri = ""
 
     fun sendChat(messageText: String) {
         viewModelScope.launch {
-            var profileUri = ""
             if (profileUri.isEmpty()) {
                 val userInfoCall = userRepository.getUserNoFirebaseUid(userUid)
                 when (userInfoCall) {
@@ -59,14 +59,16 @@ class ChatRoomViewModel @Inject constructor(
                 }
             }
 
-            val message = Message(
-                userUid,
-                preferenceRepository.getUserNickName(),
-                profileUri,
-                System.currentTimeMillis(),
-                messageText
-            )
-            addChat(message)
+            if (profileUri.isNotEmpty()) {
+                val message = Message(
+                    userUid,
+                    preferenceRepository.getUserNickName(),
+                    profileUri,
+                    System.currentTimeMillis(),
+                    messageText
+                )
+                addChat(message)
+            }
         }
     }
 

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/detail/DetailFragment.kt
@@ -12,7 +12,6 @@ import androidx.navigation.fragment.navArgs
 import com.google.android.material.tabs.TabLayoutMediator
 import com.ranicorp.letswatchfootballtogether.R
 import com.ranicorp.letswatchfootballtogether.databinding.FragmentDetailBinding
-import com.ranicorp.letswatchfootballtogether.ui.common.Event
 import com.ranicorp.letswatchfootballtogether.ui.common.EventObserver
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -92,7 +91,7 @@ class DetailFragment : Fragment() {
 
     private fun setParticipateBtn() {
         binding.btnParticipate.setOnClickListener {
-            if (viewModel.isParticipated.value == Event(true)) {
+            if (viewModel.isParticipated.value == true) {
                 Toast.makeText(
                     context,
                     getString(R.string.guide_message_already_participated),
@@ -117,7 +116,7 @@ class DetailFragment : Fragment() {
 
     private fun setJoinChatBtn() {
         binding.btnJoinChat.setOnClickListener {
-            if (viewModel.isParticipated.value == Event(true)) {
+            if (viewModel.isParticipated.value == true) {
                 TODO("채팅방으로 이동")
             } else {
                 Toast.makeText(

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/detail/DetailFragment.kt
@@ -12,6 +12,8 @@ import androidx.navigation.fragment.navArgs
 import com.google.android.material.tabs.TabLayoutMediator
 import com.ranicorp.letswatchfootballtogether.R
 import com.ranicorp.letswatchfootballtogether.databinding.FragmentDetailBinding
+import com.ranicorp.letswatchfootballtogether.ui.common.Event
+import com.ranicorp.letswatchfootballtogether.ui.common.EventObserver
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -49,6 +51,24 @@ class DetailFragment : Fragment() {
             findNavController().navigateUp()
         }
         setPostDetail()
+        viewModel.isLoaded.observe(viewLifecycleOwner, EventObserver {
+            if (!it) {
+                Toast.makeText(
+                    context,
+                    getString(R.string.error_message_not_loaded),
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+        })
+        viewModel.isParticipateCompleted.observe(viewLifecycleOwner, EventObserver {
+            if (!it) {
+                Toast.makeText(
+                    context,
+                    getString(R.string.error_message_participate_failed),
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+        })
         setParticipateBtn()
         setJoinChatBtn()
     }
@@ -66,13 +86,13 @@ class DetailFragment : Fragment() {
             bannerAdapter.submitBannersList(it.imageLocations)
         }
         viewModel.participantsInfo.observe(viewLifecycleOwner) {
-            participantsAdapter.submitList(it)
+            participantsAdapter.submitList(it.content)
         }
     }
 
     private fun setParticipateBtn() {
         binding.btnParticipate.setOnClickListener {
-            if (viewModel.isParticipated.value == true) {
+            if (viewModel.isParticipated.value == Event(true)) {
                 Toast.makeText(
                     context,
                     getString(R.string.guide_message_already_participated),
@@ -97,7 +117,7 @@ class DetailFragment : Fragment() {
 
     private fun setJoinChatBtn() {
         binding.btnJoinChat.setOnClickListener {
-            if (viewModel.isParticipated.value == true) {
+            if (viewModel.isParticipated.value == Event(true)) {
                 TODO("채팅방으로 이동")
             } else {
                 Toast.makeText(

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/detail/DetailViewModel.kt
@@ -1,14 +1,19 @@
 package com.ranicorp.letswatchfootballtogether.ui.detail
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ranicorp.letswatchfootballtogether.data.model.Post
 import com.ranicorp.letswatchfootballtogether.data.model.User
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiResultError
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiResultException
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiResultSuccess
 import com.ranicorp.letswatchfootballtogether.data.source.repository.PostRepository
 import com.ranicorp.letswatchfootballtogether.data.source.repository.UserPreferenceRepository
 import com.ranicorp.letswatchfootballtogether.data.source.repository.UserRepository
+import com.ranicorp.letswatchfootballtogether.ui.common.Event
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -23,21 +28,42 @@ class DetailViewModel @Inject constructor(
     private val _selectedPost = MutableLiveData<Post>()
     val selectedPost: LiveData<Post> = _selectedPost
     private val participantsUidList = mutableListOf<String>()
-    private val _participantsInfo = MutableLiveData<MutableList<User>>()
-    val participantsInfo: LiveData<MutableList<User>> = _participantsInfo
-    private val _isParticipated = MutableLiveData<Boolean>()
-    val isParticipated: LiveData<Boolean> = _isParticipated
+    private val _participantsInfo = MutableLiveData<Event<MutableList<User>>>()
+    val participantsInfo: LiveData<Event<MutableList<User>>> = _participantsInfo
+    private val _isLoaded = MutableLiveData<Event<Boolean>>()
+    val isLoaded: LiveData<Event<Boolean>> = _isLoaded
+    private val _isParticipated = MutableLiveData<Event<Boolean>>()
+    val isParticipated: LiveData<Event<Boolean>> = _isParticipated
+    private val _isParticipateCompleted = MutableLiveData<Event<Boolean>>()
+    val isParticipateCompleted: LiveData<Event<Boolean>> = _isParticipateCompleted
     private val userUid = userPreferenceRepository.getUserUid()
-    private lateinit var firebaseUid: String
+    private var firebaseUid = ""
 
     fun getPostDetail(postUid: String) {
         viewModelScope.launch {
-            val postResponse = postRepository.getPostNoFirebaseUid(postUid).body()
-            firebaseUid = postResponse?.keys?.first().toString()
-            _selectedPost.value = postResponse?.values?.first()
-            participantsUidList.addAll(selectedPost.value?.participantsUidList ?: emptyList())
-            getParticipantsDetail()
-            isUserParticipated()
+            val postResponse = postRepository.getPostNoFirebaseUid(postUid)
+            when (postResponse) {
+                is ApiResultSuccess -> {
+                    firebaseUid = postResponse.data.keys.first()
+                    _selectedPost.value = postResponse.data.values.first()
+                    participantsUidList.addAll(
+                        selectedPost.value?.participantsUidList ?: emptyList()
+                    )
+                    getParticipantsDetail()
+                    isUserParticipated()
+                }
+                is ApiResultError -> {
+                    _isLoaded.value = Event(false)
+                    Log.d(
+                        "DetailViewModel",
+                        "Error code: ${postResponse.code}, message: ${postResponse.message}"
+                    )
+                }
+                is ApiResultException -> {
+                    _isLoaded.value = Event(false)
+                    Log.d("DetailViewModel", "Exception: ${postResponse.throwable}")
+                }
+            }
         }
     }
 
@@ -46,34 +72,115 @@ class DetailViewModel @Inject constructor(
             val participantsUidList = selectedPost.value?.participantsUidList
             val participantsList = mutableListOf<User>()
             participantsUidList?.forEach { participantUid ->
-                participantsList.add(
-                    userRepository.getUserNoFirebaseUid(participantUid).body()?.values?.first()
-                        ?: TODO()
-                )
+                val userInfoCall = userRepository.getUserNoFirebaseUid(participantUid)
+                when (userInfoCall) {
+                    is ApiResultSuccess -> {
+                        participantsList.add(userInfoCall.data.values.first())
+                    }
+                    is ApiResultError -> {
+                        _isLoaded.value = Event(false)
+                        Log.d(
+                            "DetailViewModel",
+                            "Error code: ${userInfoCall.code}, message: ${userInfoCall.message}"
+                        )
+                    }
+                    is ApiResultException -> {
+                        _isLoaded.value = Event(false)
+                        Log.d("DetailViewModel", "Exception: ${userInfoCall.throwable}")
+                    }
+                }
             }
-            _participantsInfo.value = mutableListOf<User>().apply { addAll(participantsList) }
+            _participantsInfo.value =
+                Event(mutableListOf<User>().apply { addAll(participantsList) })
         }
     }
 
+
     private fun isUserParticipated() {
         _isParticipated.value =
-            participantsUidList.contains(userUid)
+            Event(participantsUidList.contains(userUid))
     }
 
     fun participate() {
         viewModelScope.launch {
+            val userInfo = getUserInfo() ?: return@launch
+
             val post = _selectedPost.value
             post?.participantsUidList?.add(userUid)
-            postRepository.updatePost(selectedPost.value?.postUid ?: TODO(), firebaseUid, post ?: TODO())
-
-            val userResponse = userRepository.getUserNoFirebaseUid(userUid)
-            val userFirebaseUid = userResponse.body()?.keys?.first() ?: ""
-            val user = userResponse.body()?.values?.first()
-            user?.participatingEvent?.add(post.postUid)
-            userRepository.updateUser(userUid, userFirebaseUid, user ?: TODO())
-
-            getPostDetail(post.postUid)
-            _isParticipated.value = true
+            val updatePostResponse = postRepository.updatePost(
+                selectedPost.value?.postUid ?: "",
+                firebaseUid,
+                post ?: TODO()
+            )
+            when (updatePostResponse) {
+                is ApiResultSuccess -> {
+                    updateUser(userInfo, post.postUid)
+                }
+                is ApiResultError -> {
+                    _isParticipateCompleted.value = Event(false)
+                    Log.d(
+                        "DetailViewModel",
+                        "Error code: ${updatePostResponse.code}, message: ${updatePostResponse.message}"
+                    )
+                }
+                is ApiResultException -> {
+                    _isParticipateCompleted.value = Event(false)
+                    Log.d("DetailViewModel", "Exception: ${updatePostResponse.throwable}")
+                }
+            }
         }
+    }
+
+    private fun updateUser(userInfo: Map<String, User>, postUid: String) {
+        viewModelScope.launch {
+            val userFirebaseUid = userInfo.keys.first()
+            val user = userInfo.values.first()
+            user.participatingEvent.add(postUid)
+            val updateUserCall = userRepository.updateUser(userUid, userFirebaseUid, user)
+            when (updateUserCall) {
+                is ApiResultSuccess -> {
+                    getPostDetail(postUid)
+                    _isParticipated.value = Event(true)
+                    _isParticipateCompleted.value = Event(true)
+                }
+                is ApiResultError -> {
+                    _isParticipateCompleted.value = Event(false)
+                    Log.d(
+                        "DetailViewModel",
+                        "Error code: ${updateUserCall.code}, message: ${updateUserCall.message}"
+                    )
+                }
+                is ApiResultException -> {
+                    _isParticipateCompleted.value = Event(false)
+                    Log.d("DetailViewModel", "Exception: ${updateUserCall.throwable}")
+                }
+            }
+        }
+    }
+
+    private fun getUserInfo(): Map<String, User>? {
+        var userInfo: Map<String, User>? = emptyMap()
+        viewModelScope.launch {
+            val userResponse = userRepository.getUserNoFirebaseUid(userUid)
+            when (userResponse) {
+                is ApiResultSuccess -> {
+                    userInfo = userResponse.data
+                }
+                is ApiResultError -> {
+                    _isParticipateCompleted.value = Event(false)
+                    Log.d(
+                        "DetailViewModel",
+                        "Error code: ${userResponse.code}, message: ${userResponse.message}"
+                    )
+                    userInfo = null
+                }
+                is ApiResultException -> {
+                    _isParticipateCompleted.value = Event(false)
+                    Log.d("DetailViewModel", "Exception: ${userResponse.throwable}")
+                    userInfo = null
+                }
+            }
+        }
+        return userInfo
     }
 }

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/home/HomeFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -59,6 +60,15 @@ class HomeFragment : Fragment(), PostClickListener {
                 getString(R.string.header_all_posts)
             )
             binding.refreshLayout.isRefreshing = false
+        })
+        viewModel.isLoadingComplete.observe(viewLifecycleOwner, EventObserver {
+            if (!it) {
+                Toast.makeText(
+                    context,
+                    getString(R.string.error_message_loading_failed),
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
         })
     }
 

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/home/HomeViewModel.kt
@@ -1,10 +1,14 @@
 package com.ranicorp.letswatchfootballtogether.ui.home
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ranicorp.letswatchfootballtogether.data.model.Post
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiResultError
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiResultException
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiResultSuccess
 import com.ranicorp.letswatchfootballtogether.data.source.repository.PostRepository
 import com.ranicorp.letswatchfootballtogether.ui.common.Event
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,12 +20,29 @@ class HomeViewModel @Inject constructor(private val postRepository: PostReposito
 
     private val _allPosts = MutableLiveData<Event<List<Post>>>()
     val allPosts: LiveData<Event<List<Post>>> = _allPosts
+    private val _isLoadingComplete = MutableLiveData<Event<Boolean>>()
+    val isLoadingComplete: LiveData<Event<Boolean>> = _isLoadingComplete
 
     fun loadAllPosts() {
         viewModelScope.launch {
-            _allPosts.value =
-                Event(postRepository.getAllPosts().body()?.values?.flatMap { it.values }
-                    ?: emptyList())
+            val loadAllPostsResult = postRepository.getAllPosts()
+            when (loadAllPostsResult) {
+                is ApiResultSuccess -> {
+                    _allPosts.value = Event(loadAllPostsResult.data.values.flatMap { it.values })
+                    _isLoadingComplete.value = Event(true)
+                }
+                is ApiResultError -> {
+                    _isLoadingComplete.value = Event(false)
+                    Log.d(
+                        "HomeViewModel",
+                        "Error code: ${loadAllPostsResult.code}, message: ${loadAllPostsResult.message}"
+                    )
+                }
+                is ApiResultException -> {
+                    _isLoadingComplete.value = Event(false)
+                    Log.d("HomeViewModel", "Exception: ${loadAllPostsResult.throwable}")
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/DeleteClickListener.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/DeleteClickListener.kt
@@ -1,6 +1,0 @@
-package com.ranicorp.letswatchfootballtogether.ui.posting
-
-interface DeleteClickListener {
-
-    fun onDeleteClick(uri: String)
-}

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/HeaderAdapter.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/HeaderAdapter.kt
@@ -3,53 +3,64 @@ package com.ranicorp.letswatchfootballtogether.ui.posting
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.ranicorp.letswatchfootballtogether.data.model.ImageContentHeader
 import com.ranicorp.letswatchfootballtogether.databinding.ItemImageHeaderBinding
 
-class HeaderAdapter(private val headerClickListener: HeaderClickListener) :
+class HeaderAdapter(private val listener: ImageRequestListener) :
     RecyclerView.Adapter<HeaderAdapter.HeaderViewHolder>() {
 
-    private var numberOfImage = ""
+    private val items = mutableListOf<ImageContentHeader>()
+    private var itemLimit = 0
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int
     ): HeaderViewHolder {
-        return HeaderViewHolder.from(parent, headerClickListener)
+        return HeaderViewHolder.from(parent)
     }
 
     override fun onBindViewHolder(holder: HeaderViewHolder, position: Int) {
-        holder.bind(numberOfImage)
+        holder.bind(items[position], listener)
     }
 
     override fun getItemCount(): Int {
-        return 1
+        return items.size
     }
 
-    fun submitList(sizeOfImage: String) {
-        numberOfImage = sizeOfImage
+    fun setImageHeader(limit: Int) {
+        itemLimit = limit
+        items.add(ImageContentHeader(0, limit))
+        notifyItemChanged(0)
+    }
+
+    fun updateImageHeader(currentSize: Int) {
+        items[0] = ImageContentHeader(currentSize, itemLimit)
+        notifyItemChanged(0)
+    }
+
+    fun removeImage() {
+        val currentSize = items[0].size
+        items[0] = ImageContentHeader(currentSize - 1, itemLimit)
+        notifyItemChanged(0)
     }
 
     class HeaderViewHolder(
-        private val binding: ItemImageHeaderBinding,
-        private val headerClickListener: HeaderClickListener
+        private val binding: ItemImageHeaderBinding
     ) : RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(numberOfImage: String) {
-            binding.numberOfImage = numberOfImage
-            binding.headerClickListener = headerClickListener
+        fun bind(header: ImageContentHeader, listener: ImageRequestListener) {
+            binding.header = header
+            binding.imageRequestListener = listener
         }
 
         companion object {
-            fun from(
-                parent: ViewGroup,
-                headerClickListener: HeaderClickListener
-            ): HeaderViewHolder {
+            fun from(parent: ViewGroup): HeaderViewHolder {
                 return HeaderViewHolder(
                     ItemImageHeaderBinding.inflate(
-                        LayoutInflater.from(
-                            parent.context
-                        ), parent, false
-                    ), headerClickListener
+                        LayoutInflater.from(parent.context),
+                        parent,
+                        false
+                    )
                 )
             }
         }

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/HeaderClickListener.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/HeaderClickListener.kt
@@ -1,6 +1,0 @@
-package com.ranicorp.letswatchfootballtogether.ui.posting
-
-interface HeaderClickListener {
-
-    fun onHeaderClick()
-}

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/ImageAdapter.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/ImageAdapter.kt
@@ -3,54 +3,66 @@ package com.ranicorp.letswatchfootballtogether.ui.posting
 import android.net.Uri
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.ranicorp.letswatchfootballtogether.data.model.ImageContent
 import com.ranicorp.letswatchfootballtogether.databinding.ItemAttachedImageBinding
 
-class ImageAdapter(private val deleteClickListener: DeleteClickListener) :
-    ListAdapter<Uri, ImageAdapter.ImageViewHolder>(ImageDiffCallback()) {
+class ImageAdapter(private val limit: Int, private val listener: ImageUpdateListener) :
+    RecyclerView.Adapter<ImageAdapter.ImageViewHolder>() {
+
+    private val items = mutableListOf<ImageContent>()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ImageViewHolder {
-        return ImageViewHolder.from(parent, deleteClickListener)
+        return ImageViewHolder.from(parent)
     }
 
     override fun onBindViewHolder(holder: ImageViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        holder.bind(position, items[position], listener)
     }
 
-    class ImageViewHolder(
-        private val binding: ItemAttachedImageBinding,
-        private val deleteClickListener: DeleteClickListener
-    ) : RecyclerView.ViewHolder(binding.root) {
+    override fun getItemCount(): Int {
+        return items.size
+    }
 
-        fun bind(uri: Uri) {
-            binding.imageUri = uri.toString()
-            binding.deleteClickListener = deleteClickListener
+    fun getItems(): List<ImageContent> {
+        return items
+    }
+
+    fun addImage(uri: Uri) {
+        val position = items.size
+        if (position < limit) {
+            items.add(ImageContent(uri))
+            notifyItemInserted(position)
+        }
+    }
+
+    fun removeImage(position: Int) {
+        items.removeAt(position)
+        notifyItemRemoved(position)
+    }
+
+    class ImageViewHolder(private val binding: ItemAttachedImageBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(pos: Int, item: ImageContent, updateListener: ImageUpdateListener) {
+            with(binding) {
+                position = pos
+                imageContent = item
+                listener = updateListener
+            }
         }
 
         companion object {
-            fun from(parent: ViewGroup, deleteClickListener: DeleteClickListener)
-                    : ImageViewHolder {
+            fun from(parent: ViewGroup): ImageViewHolder {
                 return ImageViewHolder(
                     ItemAttachedImageBinding.inflate(
-                        LayoutInflater.from(
-                            parent.context
-                        ), parent, false
-                    ), deleteClickListener
+                        LayoutInflater.from(parent.context),
+                        parent,
+                        false
+                    )
                 )
             }
         }
-    }
-}
-
-class ImageDiffCallback : DiffUtil.ItemCallback<Uri>() {
-    override fun areItemsTheSame(oldItem: Uri, newItem: Uri): Boolean {
-        return oldItem == newItem
-    }
-
-    override fun areContentsTheSame(oldItem: Uri, newItem: Uri): Boolean {
-        return oldItem == newItem
     }
 }
 

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/ImageRequestListener.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/ImageRequestListener.kt
@@ -1,0 +1,6 @@
+package com.ranicorp.letswatchfootballtogether.ui.posting
+
+interface ImageRequestListener {
+
+    fun onImageContentRequest()
+}

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/ImageUpdateListener.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/ImageUpdateListener.kt
@@ -1,0 +1,6 @@
+package com.ranicorp.letswatchfootballtogether.ui.posting
+
+interface ImageUpdateListener {
+
+    fun removeImage(position: Int)
+}

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/PostingFragment.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/PostingFragment.kt
@@ -73,6 +73,12 @@ class PostingFragment : Fragment(), DeleteClickListener, HeaderClickListener {
         viewModel.isComplete.observe(viewLifecycleOwner, EventObserver {
             if (it) {
                 findNavController().navigateUp()
+            } else {
+                Toast.makeText(
+                    context,
+                    getString(R.string.error_message_post_failed),
+                    Toast.LENGTH_SHORT
+                ).show()
             }
         })
     }
@@ -99,7 +105,7 @@ class PostingFragment : Fragment(), DeleteClickListener, HeaderClickListener {
     }
 
     private fun setAdapter() {
-        binding.imageRecyclerView.adapter =
+        binding.rvImage.adapter =
             ConcatAdapter(attachedImageHeaderAdapter, attachedImageAdapter)
         attachedImageHeaderAdapter.submitList(getString(R.string.number_of_image_displayed, 0))
     }

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/PostingFragment.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/PostingFragment.kt
@@ -18,7 +18,6 @@ import com.google.android.material.timepicker.TimeFormat
 import com.ranicorp.letswatchfootballtogether.R
 import com.ranicorp.letswatchfootballtogether.databinding.FragmentPostingBinding
 import com.ranicorp.letswatchfootballtogether.ui.common.EventObserver
-import com.ranicorp.letswatchfootballtogether.ui.common.ProgressDialogFragment
 import com.ranicorp.letswatchfootballtogether.util.DateFormatText
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -37,7 +36,6 @@ class PostingFragment : Fragment(), DeleteClickListener, HeaderClickListener {
     private val attachedImageAdapter = ImageAdapter(this)
     private val attachedImageHeaderAdapter = HeaderAdapter(this)
     private val viewModel: PostingViewModel by viewModels()
-    private val progressDialog = ProgressDialogFragment()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -120,9 +118,7 @@ class PostingFragment : Fragment(), DeleteClickListener, HeaderClickListener {
         })
         viewModel.isLoading.observe(viewLifecycleOwner, EventObserver {
             if (it) {
-                progressDialog.show(requireActivity().supportFragmentManager, null)
-            } else {
-                progressDialog.dismiss()
+                findNavController().navigate(PostingFragmentDirections.actionPostingFragmentToProgressDialogFragment())
             }
         })
     }

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/PostingFragment.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/PostingFragment.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
@@ -22,19 +21,17 @@ import com.ranicorp.letswatchfootballtogether.util.DateFormatText
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class PostingFragment : Fragment(), DeleteClickListener, HeaderClickListener {
+class PostingFragment : Fragment(), ImageRequestListener, ImageUpdateListener {
 
     private var _binding: FragmentPostingBinding? = null
     private val binding get() = _binding!!
-    private val getContent =
-        registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
-            if (uri != null) {
-                viewModel.addImage(uri)
-                updateAdapterData()
-            }
+    private val getMultipleContents =
+        registerForActivityResult(ActivityResultContracts.GetMultipleContents()) {
+            addImageList(it)
         }
-    private val attachedImageAdapter = ImageAdapter(this)
-    private val attachedImageHeaderAdapter = HeaderAdapter(this)
+    private val imageCountLimit = 10
+    private val imageListAdapter = ImageAdapter(imageCountLimit, this)
+    private val imageHeaderAdapter = HeaderAdapter(this)
     private val viewModel: PostingViewModel by viewModels()
 
     override fun onCreateView(
@@ -53,19 +50,8 @@ class PostingFragment : Fragment(), DeleteClickListener, HeaderClickListener {
         setLayout()
     }
 
-    private fun updateAdapterData() {
-        attachedImageAdapter.submitList(viewModel.imageUriList.value?.content)
-        attachedImageHeaderAdapter.submitList(
-            getString(
-                R.string.number_of_image_displayed,
-                viewModel.imageUriList.value?.content?.size
-            )
-        )
-        attachedImageHeaderAdapter.notifyDataSetChanged()
-    }
-
     private fun setLayout() {
-        setAdapter()
+        setImageList()
         setObservers()
         setOnClickListeners()
         viewModel.isComplete.observe(viewLifecycleOwner, EventObserver {
@@ -77,6 +63,27 @@ class PostingFragment : Fragment(), DeleteClickListener, HeaderClickListener {
                     getString(R.string.error_message_post_failed),
                     Toast.LENGTH_SHORT
                 ).show()
+            }
+        })
+    }
+
+    private fun setImageList() {
+        imageHeaderAdapter.setImageHeader(imageCountLimit)
+        binding.rvImage.adapter =
+            ConcatAdapter(imageHeaderAdapter, imageListAdapter)
+    }
+
+    private fun setObservers() {
+        viewModel.errorMsgResId.observe(viewLifecycleOwner, EventObserver {
+            Toast.makeText(
+                context,
+                getString(it),
+                Toast.LENGTH_SHORT
+            ).show()
+        })
+        viewModel.isLoading.observe(viewLifecycleOwner, EventObserver {
+            if (it) {
+                findNavController().navigate(PostingFragmentDirections.actionPostingFragmentToProgressDialogFragment())
             }
         })
     }
@@ -100,27 +107,6 @@ class PostingFragment : Fragment(), DeleteClickListener, HeaderClickListener {
         binding.postingToolbar.setNavigationOnClickListener {
             findNavController().navigateUp()
         }
-    }
-
-    private fun setAdapter() {
-        binding.rvImage.adapter =
-            ConcatAdapter(attachedImageHeaderAdapter, attachedImageAdapter)
-        attachedImageHeaderAdapter.submitList(getString(R.string.number_of_image_displayed, 0))
-    }
-
-    private fun setObservers() {
-        viewModel.errorMsgResId.observe(viewLifecycleOwner, EventObserver {
-            Toast.makeText(
-                context,
-                getString(it),
-                Toast.LENGTH_SHORT
-            ).show()
-        })
-        viewModel.isLoading.observe(viewLifecycleOwner, EventObserver {
-            if (it) {
-                findNavController().navigate(PostingFragmentDirections.actionPostingFragmentToProgressDialogFragment())
-            }
-        })
     }
 
     private fun chooseDate() {
@@ -162,20 +148,28 @@ class PostingFragment : Fragment(), DeleteClickListener, HeaderClickListener {
         _binding = null
     }
 
-    override fun onDeleteClick(uri: String) {
-        viewModel.removeImage(uri.toUri())
-        updateAdapterData()
+    private fun addImageList(uriList: List<Uri>) {
+        for (uri in uriList) {
+            imageListAdapter.addImage(uri)
+        }
+        imageHeaderAdapter.updateImageHeader(imageListAdapter.itemCount)
+        viewModel.updateImageList(imageListAdapter.getItems())
     }
 
-    override fun onHeaderClick() {
-        if (viewModel.imageUriList.value?.content?.size == 10) {
+    override fun onImageContentRequest() {
+        if (imageListAdapter.itemCount == 10) {
             Toast.makeText(
                 context,
                 getString(R.string.guide_message_limit_max_images),
                 Toast.LENGTH_SHORT
             ).show()
         } else {
-            getContent.launch("image/*")
+            getMultipleContents.launch("image/*")
         }
+    }
+
+    override fun removeImage(position: Int) {
+        imageListAdapter.removeImage(position)
+        imageHeaderAdapter.removeImage()
     }
 }

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/PostingViewModel.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/posting/PostingViewModel.kt
@@ -43,7 +43,7 @@ class PostingViewModel @Inject constructor(
     private val _imageUriList: MutableLiveData<Event<MutableList<Uri>>> = MutableLiveData()
     val imageUriList: LiveData<Event<MutableList<Uri>>> = _imageUriList
     private val isPostAdded = MutableLiveData(Event(false))
-    private val _isLoading = MutableLiveData(Event(false))
+    private val _isLoading: MutableLiveData<Event<Boolean>> = MutableLiveData()
     val isLoading: LiveData<Event<Boolean>> = _isLoading
     private val _isComplete: MutableLiveData<Event<Boolean>> = MutableLiveData()
     val isComplete: LiveData<Event<Boolean>> = _isComplete

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/setting/SettingFragment.kt
@@ -64,6 +64,15 @@ class SettingFragment : Fragment() {
                 setErrorMsg(errorMsg)
             })
         }
+        viewModel.isInputComplete.observe(viewLifecycleOwner, EventObserver {
+            if(!it) {
+                Toast.makeText(
+                    context,
+                    getString(R.string.error_message_setting_input_not_complete),
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+        })
         viewModel.isSettingComplete.observe(viewLifecycleOwner, EventObserver {
             if (it) {
                 findNavController().navigate(SettingFragmentDirections.actionSettingFragmentToHomeFragment())

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/setting/SettingFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -66,8 +67,23 @@ class SettingFragment : Fragment() {
         viewModel.isSettingComplete.observe(viewLifecycleOwner, EventObserver {
             if (it) {
                 findNavController().navigate(SettingFragmentDirections.actionSettingFragmentToHomeFragment())
+            } else {
+                Toast.makeText(
+                    context,
+                    getString(R.string.error_message_setting_failed),
+                    Toast.LENGTH_SHORT
+                ).show()
             }
         })
+        viewModel.hasAllNickName.observe(viewLifecycleOwner) {
+            if (!it) {
+                Toast.makeText(
+                    context,
+                    getString(R.string.error_message_setting_not_available),
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+        }
     }
 
     private fun setErrorMsg(errorMsg: String?) {

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/setting/SettingViewModel.kt
@@ -1,5 +1,6 @@
 package com.ranicorp.letswatchfootballtogether.ui.setting
 
+import android.util.Log
 import androidx.core.net.toUri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -7,6 +8,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.storage.FirebaseStorage
 import com.ranicorp.letswatchfootballtogether.data.model.User
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiResultError
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiResultException
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiResultSuccess
 import com.ranicorp.letswatchfootballtogether.data.source.repository.UserPreferenceRepository
 import com.ranicorp.letswatchfootballtogether.data.source.repository.UserRepository
 import com.ranicorp.letswatchfootballtogether.ui.common.Event
@@ -30,9 +34,12 @@ class SettingViewModel @Inject constructor(
     val errorMsg: LiveData<Event<String?>> = _errorType
     private val isValidProfileUri: MutableLiveData<Boolean> = MutableLiveData()
     private val isValidNickName: MutableLiveData<Boolean> = MutableLiveData()
-    private val existingNickName: MutableLiveData<Collection<String>> = MutableLiveData()
+    private val existingNickName: MutableLiveData<List<String>> = MutableLiveData()
     private val _isSettingComplete = MutableLiveData(Event(false))
     val isSettingComplete: LiveData<Event<Boolean>> = _isSettingComplete
+    private val isAddUserComplete = MutableLiveData(false)
+    private val isAddNickNameComplete = MutableLiveData(false)
+    val hasAllNickName: MutableLiveData<Boolean> = MutableLiveData()
 
     fun setProfileUri(uri: String) {
         profileUri.value = uri
@@ -56,6 +63,7 @@ class SettingViewModel @Inject constructor(
     }
 
     private fun verifyDuplicateNickName(nickName: String) {
+        if (hasAllNickName.value == false) return
         if (existingNickName.value?.contains(nickName) == false) {
             isValidNickName.value = true
             _errorType.value = Event(null)
@@ -67,8 +75,24 @@ class SettingViewModel @Inject constructor(
 
     fun updateExistingNickNameList() {
         viewModelScope.launch {
-            existingNickName.value =
-                userRepository.getUserNickNames().body()?.values ?: emptyList()
+            val networkResult = userRepository.getUserNickNames()
+            when (networkResult) {
+                is ApiResultSuccess -> {
+                    existingNickName.value = networkResult.data.values.toList()
+                    hasAllNickName.value = true
+                }
+                is ApiResultError -> {
+                    hasAllNickName.value = false
+                    Log.d(
+                        "SettingViewModel",
+                        "Error code: ${networkResult.code}, message: ${networkResult.message}"
+                    )
+                }
+                is ApiResultException -> {
+                    hasAllNickName.value = false
+                    Log.d("SettingViewModel", "Exception: ${networkResult.throwable}")
+                }
+            }
         }
     }
 
@@ -86,16 +110,60 @@ class SettingViewModel @Inject constructor(
                     imageLocations,
                     mutableListOf()
                 )
-            if (userRepository.addUser(
-                    googleUid,
-                    user
-                ).isSuccessful && userRepository.addUserNickName(nickName.value!!).isSuccessful
-            ) {
+
+            addUserCall(googleUid, user)
+            addNickNameCall()
+            if (isAddNickNameComplete.value == true && isAddUserComplete.value == true) {
                 _isSettingComplete.value = Event(true)
+                userPreferenceRepository.saveUserInfo(googleUid)
+                userPreferenceRepository.saveUserNickName(nickName.value!!)
+            } else {
+                _isSettingComplete.value = Event(false)
             }
         }
-        userPreferenceRepository.saveUserInfo(googleUid)
-        userPreferenceRepository.saveUserNickName(nickName.value!!)
+    }
+
+    private suspend fun addNickNameCall() {
+        val addUserNickNameResult = userRepository.addUserNickName(nickName.value!!)
+        when (addUserNickNameResult) {
+            is ApiResultSuccess -> {
+                isAddNickNameComplete.value = true
+            }
+            is ApiResultError -> {
+                isAddNickNameComplete.value = false
+                Log.d(
+                    "SettingViewModel",
+                    "Error code: ${addUserNickNameResult.code}, message: ${addUserNickNameResult.message}"
+                )
+            }
+            is ApiResultException -> {
+                isAddNickNameComplete.value = false
+                Log.d("SettingViewModel", "Exception: ${addUserNickNameResult.throwable}")
+            }
+        }
+    }
+
+    private suspend fun addUserCall(googleUid: String, user: User) {
+        val addUserResult = userRepository.addUser(
+            googleUid,
+            user
+        )
+        when (addUserResult) {
+            is ApiResultSuccess -> {
+                isAddUserComplete.value = true
+            }
+            is ApiResultError -> {
+                isAddUserComplete.value = false
+                Log.d(
+                    "SettingViewModel",
+                    "Error code: ${addUserResult.code}, message: ${addUserResult.message}"
+                )
+            }
+            is ApiResultException -> {
+                isAddUserComplete.value = false
+                Log.d("SettingViewModel", "Exception: ${addUserResult.throwable}")
+            }
+        }
     }
 
     private suspend fun addImageToStorage(profileUri: String): String = coroutineScope {

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/setting/SettingViewModel.kt
@@ -41,7 +41,8 @@ class SettingViewModel @Inject constructor(
     val isInputComplete: LiveData<Event<Boolean>> = _isInputComplete
     private val isAddUserComplete = MutableLiveData(false)
     private val isAddNickNameComplete = MutableLiveData(false)
-    val hasAllNickName: MutableLiveData<Boolean> = MutableLiveData()
+    private val _hasAllNickName: MutableLiveData<Boolean> = MutableLiveData()
+    val hasAllNickName: LiveData<Boolean> = _hasAllNickName
 
     fun setProfileUri(uri: String) {
         profileUri.value = uri
@@ -81,17 +82,17 @@ class SettingViewModel @Inject constructor(
             when (networkResult) {
                 is ApiResultSuccess -> {
                     existingNickName.value = networkResult.data.values.toList()
-                    hasAllNickName.value = true
+                    _hasAllNickName.value = true
                 }
                 is ApiResultError -> {
-                    hasAllNickName.value = false
+                    _hasAllNickName.value = false
                     Log.d(
                         "SettingViewModel",
                         "Error code: ${networkResult.code}, message: ${networkResult.message}"
                     )
                 }
                 is ApiResultException -> {
-                    hasAllNickName.value = false
+                    _hasAllNickName.value = false
                     Log.d("SettingViewModel", "Exception: ${networkResult.throwable}")
                 }
             }

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/setting/SettingViewModel.kt
@@ -35,8 +35,10 @@ class SettingViewModel @Inject constructor(
     private val isValidProfileUri: MutableLiveData<Boolean> = MutableLiveData()
     private val isValidNickName: MutableLiveData<Boolean> = MutableLiveData()
     private val existingNickName: MutableLiveData<List<String>> = MutableLiveData()
-    private val _isSettingComplete = MutableLiveData(Event(false))
+    private val _isSettingComplete: MutableLiveData<Event<Boolean>> = MutableLiveData()
     val isSettingComplete: LiveData<Event<Boolean>> = _isSettingComplete
+    private val _isInputComplete: MutableLiveData<Event<Boolean>> = MutableLiveData()
+    val isInputComplete: LiveData<Event<Boolean>> = _isInputComplete
     private val isAddUserComplete = MutableLiveData(false)
     private val isAddNickNameComplete = MutableLiveData(false)
     val hasAllNickName: MutableLiveData<Boolean> = MutableLiveData()
@@ -97,11 +99,14 @@ class SettingViewModel @Inject constructor(
     }
 
     fun addUser(googleUid: String) {
-        if (profileUri.value.isNullOrEmpty() || nickName.value.isNullOrEmpty()) {
+        val validInput = isValidProfileUri.value == true && isValidNickName.value == true
+        if (!validInput) {
+            _isInputComplete.value = Event(false)
             return
         }
 
         viewModelScope.launch {
+            _isInputComplete.value = Event(true)
             val imageLocations = addImageToStorage(profileUri.value!!)
             val user =
                 User(

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/signIn/SignInFragment.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/signIn/SignInFragment.kt
@@ -61,6 +61,15 @@ class SignInFragment : Fragment() {
         binding.btnSignInWithGoogle.setOnClickListener {
             onClick()
         }
+        viewModel.hasAllUsers.observe(viewLifecycleOwner) {
+            if (it == false) {
+                Toast.makeText(
+                    context,
+                    getString(R.string.error_message_sign_in_not_available),
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+        }
     }
 
     private fun setActivityResultLauncher(signInClient: SignInClient): ActivityResultLauncher<IntentSenderRequest> {

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/signIn/SignInFragment.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/signIn/SignInFragment.kt
@@ -7,10 +7,12 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.gms.auth.api.identity.BeginSignInRequest
 import com.google.android.gms.auth.api.identity.GetSignInIntentRequest
@@ -22,6 +24,7 @@ import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.ktx.Firebase
 import com.ranicorp.letswatchfootballtogether.BuildConfig
+import com.ranicorp.letswatchfootballtogether.R
 import com.ranicorp.letswatchfootballtogether.databinding.FragmentSignInBinding
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -34,6 +37,7 @@ class SignInFragment : Fragment() {
     private lateinit var oneTapClient: SignInClient
     private lateinit var signInRequest: BeginSignInRequest
     private lateinit var auth: FirebaseAuth
+    private val viewModel: SignInViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -114,8 +118,22 @@ class SignInFragment : Fragment() {
             .addOnCompleteListener { task ->
                 if (task.isSuccessful) {
                     val googleUid = auth.currentUser?.uid
-                    if (googleUid != null) {
-                        findNavController().navigate(SignInFragmentDirections.actionSignInFragmentToSettingFragment(googleUid))
+                    if (googleUid == null) {
+                        Toast.makeText(
+                            context,
+                            getString(R.string.error_message_no_google_uid),
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        return@addOnCompleteListener
+                    }
+                    viewModel.confirmExistingUid(googleUid)
+                    viewModel.hasJoined.observe(viewLifecycleOwner) {
+                        if (it) {
+                            findNavController().navigate(SignInFragmentDirections.actionSignInFragmentToHomeFragment())
+                        } else {
+                            findNavController().navigate(SignInFragmentDirections.actionSignInFragmentToSettingFragment(googleUid)
+                            )
+                        }
                     }
                 } else {
                     Log.w("TAG", "signInWithCredential:failure", task.exception)

--- a/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/signIn/SignInViewModel.kt
+++ b/app/src/main/java/com/ranicorp/letswatchfootballtogether/ui/signIn/SignInViewModel.kt
@@ -1,0 +1,60 @@
+package com.ranicorp.letswatchfootballtogether.ui.signIn
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiResultError
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiResultException
+import com.ranicorp.letswatchfootballtogether.data.source.remote.apicalladapter.ApiResultSuccess
+import com.ranicorp.letswatchfootballtogether.data.source.repository.UserPreferenceRepository
+import com.ranicorp.letswatchfootballtogether.data.source.repository.UserRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SignInViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+    private val userPreferenceRepository: UserPreferenceRepository
+) : ViewModel() {
+
+    private val _hasAllUsers: MutableLiveData<Boolean> = MutableLiveData()
+    val hasAllUsers: LiveData<Boolean> = _hasAllUsers
+    private val _hasJoined: MutableLiveData<Boolean> = MutableLiveData()
+    val hasJoined: LiveData<Boolean> = _hasJoined
+
+    fun confirmExistingUid(userFirebaseUid: String) {
+        viewModelScope.launch {
+            val networkResult = userRepository.getAllUsers()
+            when (networkResult) {
+                is ApiResultSuccess -> {
+                    val allUsersList = networkResult.data.values.flatMap { it.values }
+                    val allUsersFirebaseUidList = networkResult.data.keys.toList()
+                    _hasAllUsers.value = true
+                    _hasJoined.value = allUsersFirebaseUidList.contains(userFirebaseUid)
+                    if (_hasJoined.value == true) {
+                        val userInfo = allUsersList.filter {
+                            it.uid == userFirebaseUid
+                        }.first()
+                        userPreferenceRepository.saveUserInfo(userFirebaseUid)
+                        userPreferenceRepository.saveUserNickName(userInfo.nickName)
+                    }
+                }
+                is ApiResultError -> {
+                    _hasAllUsers.value = false
+                    Log.d(
+                        "SignInViewModel",
+                        "Error code: ${networkResult.code}, message: ${networkResult.message}"
+                    )
+                }
+                is ApiResultException -> {
+                    _hasAllUsers.value = false
+                    Log.d("SignInViewModel", "Exception: ${networkResult.throwable}")
+                }
+            }
+        }
+    }
+}
+

--- a/app/src/main/res/layout/item_attached_image.xml
+++ b/app/src/main/res/layout/item_attached_image.xml
@@ -6,12 +6,16 @@
     <data>
 
         <variable
-            name="imageUri"
-            type="String" />
+            name="position"
+            type="int" />
 
         <variable
-            name="deleteClickListener"
-            type="com.ranicorp.letswatchfootballtogether.ui.posting.DeleteClickListener" />
+            name="listener"
+            type="com.ranicorp.letswatchfootballtogether.ui.posting.ImageUpdateListener" />
+
+        <variable
+            name="imageContent"
+            type="com.ranicorp.letswatchfootballtogether.data.model.ImageContent" />
 
     </data>
 
@@ -21,7 +25,7 @@
 
         <ImageView
             android:id="@+id/ivPreview"
-            squareCropImageUri="@{imageUri}"
+            squareCropImageUri="@{imageContent.uri.toString()}"
             android:layout_width="64dp"
             android:layout_height="64dp"
             android:layout_marginTop="10dp"
@@ -39,7 +43,7 @@
             android:layout_height="20dp"
             android:layout_marginEnd="6dp"
             android:layout_marginBottom="54dp"
-            android:onClick="@{() -> deleteClickListener.onDeleteClick(imageUri)}"
+            android:onClick="@{() -> listener.removeImage(position)}"
             android:src="@drawable/ic_delete"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/item_image_header.xml
+++ b/app/src/main/res/layout/item_image_header.xml
@@ -6,12 +6,12 @@
     <data>
 
         <variable
-            name="numberOfImage"
-            type="String" />
+            name="header"
+            type="com.ranicorp.letswatchfootballtogether.data.model.ImageContentHeader" />
 
         <variable
-            name="headerClickListener"
-            type="com.ranicorp.letswatchfootballtogether.ui.posting.HeaderClickListener" />
+            name="imageRequestListener"
+            type="com.ranicorp.letswatchfootballtogether.ui.posting.ImageRequestListener" />
 
     </data>
 
@@ -25,7 +25,7 @@
             android:layout_width="64dp"
             android:layout_height="64dp"
             android:background="@drawable/background_attached_image_header"
-            android:onClick="@{() -> headerClickListener.onHeaderClick()}"
+            android:onClick="@{() -> imageRequestListener.onImageContentRequest()}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -37,25 +37,41 @@
             android:layout_height="24dp"
             android:layout_marginTop="10dp"
             android:src="@drawable/ic_camera_filled"
-            app:layout_constraintBottom_toTopOf="@id/tvNumberOfAttachedImages"
+            app:layout_constraintBottom_toTopOf="@id/tvSelectedImageSize"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
-            android:id="@+id/tvNumberOfAttachedImages"
+            android:id="@+id/tvSelectedImageSize"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:layout_marginBottom="8dp"
-            android:text="@{numberOfImage}"
-            android:textColor="@color/black"
+            android:gravity="center"
+            android:text="@{String.valueOf(header.size)}"
+            android:textColor="@color/blue"
             android:textSize="14sp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toStartOf="@id/tvSelectedImageLimit"
+            app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/ivCameraIcon"
-            tools:text="4/10" />
+            tools:text="4" />
+
+        <TextView
+            android:id="@+id/tvSelectedImageLimit"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            android:text="@{@string/number_of_image_displayed(header.limit)}"
+            android:textColor="@color/black"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tvSelectedImageSize"
+            app:layout_constraintTop_toBottomOf="@id/ivCameraIcon"
+            tools:text="/10" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/navigation/home_graph.xml
+++ b/app/src/main/res/navigation/home_graph.xml
@@ -74,7 +74,11 @@
     <fragment
         android:id="@+id/postingFragment"
         android:name="com.ranicorp.letswatchfootballtogether.ui.posting.PostingFragment"
-        android:label="PostingFragment" />
+        android:label="PostingFragment" >
+        <action
+            android:id="@+id/action_postingFragment_to_progressDialogFragment"
+            app:destination="@id/progressDialogFragment" />
+    </fragment>
     <fragment
         android:id="@+id/chatRoomListFragment"
         android:name="com.ranicorp.letswatchfootballtogether.ui.chatroomlist.ChatRoomListFragment"
@@ -84,4 +88,9 @@
             android:id="@+id/action_chatRoomListFragment_to_chatRoomFragment"
             app:destination="@id/chatRoomFragment" />
     </fragment>
+    <dialog
+        android:id="@+id/progressDialogFragment"
+        android:name="com.ranicorp.letswatchfootballtogether.ui.common.ProgressDialogFragment"
+        android:label="fragment_progress_dialog"
+        tools:layout="@layout/fragment_progress_dialog" />
 </navigation>

--- a/app/src/main/res/navigation/home_graph.xml
+++ b/app/src/main/res/navigation/home_graph.xml
@@ -13,6 +13,9 @@
         <action
             android:id="@+id/action_signInFragment_to_settingFragment"
             app:destination="@id/settingFragment" />
+        <action
+            android:id="@+id/action_signInFragment_to_homeFragment"
+            app:destination="@id/homeFragment" />
     </fragment>
     <fragment
         android:id="@+id/settingFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,8 @@
     <string name="error_message_empty_nick_name">닉네임을 입력해주세요.</string>
     <string name="error_message_max_length">20자 이내로 입력해주세요.</string>
     <string name="error_message_duplicate_nick_name">중복된 닉네임입니다.</string>
+    <string name="error_message_setting_failed">프로필 설정 실패하였습니다. 잠시후 다시 시도해주세요.</string>
+    <string name="error_message_setting_not_available">프로필 설정할 수 없습니다. 잠시후 다시 시도해주세요.</string>
 
     <!-- 글쓰기 -->
     <string name="title_write_post">모집 글쓰기</string>
@@ -42,6 +44,7 @@
     <string name="title_set_time">모임 시간을 정해주세요</string>
     <string name="label_am_time">오전 %1$d:%2$d</string>
     <string name="label_pm_time">오후 %1$d:%2$d</string>
+    <string name="error_message_post_failed">게시물 등록에 실패하였습니다. 잠시후 다시 시도해주세요.</string>
 
     <!-- 홈 -->
     <string name="title_lets_watch_football">같이 축구 볼 사람?</string>
@@ -51,6 +54,7 @@
     <string name="label_home">홈</string>
     <string name="label_chat">채팅</string>
     <string name="label_profile">프로필</string>
+    <string name="error_message_loading_failed">게시물 불러오기에 실패하였습니다. 잠시후 다시 시도해주세요.</string>
 
     <!-- 상세 화면 -->
     <string name="label_number_of_participants">참여 인원 (%1$d/%2$d명)</string>
@@ -60,8 +64,11 @@
     <string name="guide_message_exceed_maximum_participants">모집 최대 인원을 초과하였습니다.</string>
     <string name="guide_message_participate_succeeded">참여 완료되었습니다.</string>
     <string name="guide_message_join_restricted">모임에 참여한 사람만 채팅방에 입장할 수 있습니다.</string>
+    <string name="error_message_not_loaded">상세화면 불러오기에 실패하였습니다. 잠시후 다시 시도해주세요.</string>
+    <string name="error_message_participate_failed">모임에 참여 실패하였습니다. 잠시후 다시 시도해주세요.</string>
 
     <!-- 채팅방-->
     <string name="hint_write_message">메세지를 입력해주세요.</string>
+    <string name="error_message_chat_room_loading_failed">채팅방 불러오기에 실패하였습니다. 잠시후 다시 시도해주세요.</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="error_message_duplicate_nick_name">중복된 닉네임입니다.</string>
     <string name="error_message_setting_failed">프로필 설정 실패하였습니다. 잠시후 다시 시도해주세요.</string>
     <string name="error_message_setting_not_available">프로필 설정할 수 없습니다. 잠시후 다시 시도해주세요.</string>
+    <string name="error_message_setting_input_not_complete">프로필 사진, 닉네임을 모두 설정해주세요.</string>
 
     <!-- 글쓰기 -->
     <string name="title_write_post">모집 글쓰기</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,7 +36,7 @@
     <string name="label_complete">완료</string>
     <string name="hint_posting_date">날짜</string>
     <string name="guide_message_please_wait">잠시 기다려주세요.</string>
-    <string name="number_of_image_displayed">%1$d/10</string>
+    <string name="number_of_image_displayed">/%d</string>
     <string name="guide_message_set_image">이미지를 추가해주세요.</string>
     <string name="guide_message_set_title">모집명을 작성해주세요.</string>
     <string name="guide_message_set_location">장소를 추가해주세요.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,10 @@
     <string name="label_chat_destination">Chat</string>
     <string name="label_profile_destination">Profile</string>
 
+    <!-- 로그인/회원가입 -->
+    <string name="error_message_no_google_uid">구글 계정을 확인할 수 없습니다. 다시 시도해주시기 바랍니다.</string>
+    <string name="error_message_sign_in_not_available">로그인/회원가입 할 수 없습니다. 다시 시도해주시기 바랍니다.</string>
+
     <!-- 프로필 설정 -->
     <string name="guide_message_set_profile">프로필을 설정해주세요.</string>
     <string name="hint_write_nickname">닉네임을 입력해주세요.</string>


### PR DESCRIPTION
1. 구현 내용 : 지금까지 구현된 기능에 네트워크 통신 응답 결과 처리하기
- 네트워크 통신응답 인터페이스 ApiResponse를 생성하여 Success, Error, Exception 발생하는 경우로 나눔
- Call을 Call<ApiResponse<Type>>으로 변환해주는 CallAdapter을 구현함

2. 기타
- 프로필 사진/닉네임 설정: 프로필 사진, 닉네임 모두 유효하지 않으면 설정 완료할 수 없도록 구현함
- 상세화면에서 모임 참여: 참여하기 버튼 클릭시 유저 정보 먼저 가져오도록 구현 수정함
- 회원가입/로그인: 기존 가입 이력을 확인할 수 없는 경우 회원가입/로그인 진행할 수 없도록 하고, 기존에 가입한 적이 있는 회원은 바로 Home 화면으로 이동하도록 구현함